### PR TITLE
Added overhead storage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,8 @@ export const SOCIAL_FS_SCHEME = 'near';
 export const SOCIAL_CONTRACT_ACCOUNT = 'social.near';
 export const WIDGET_EXT = `.jsx`;
 export const APP_NAME = 'vscode social';
-export const COST_PER_BYTE = new BN("10000000000000000000"); // 1b
-export const DATA_OVERHEAD = 8*5 + 64*4 + 20*4; // 8 bytes for each key (len+dict-size), 64 bytes for accountId, 20bytes for widget-name
+export const COST_PER_BYTE = new BN("10000000000000000000");
+export const DATA_OVERHEAD = 336; // TODO: Compute better
 export const TGAS30 = new BN("30"+"0".repeat(12));
 
 export const defaultContext = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,8 @@ export const SOCIAL_FS_SCHEME = 'near';
 export const SOCIAL_CONTRACT_ACCOUNT = 'social.near';
 export const WIDGET_EXT = `.jsx`;
 export const APP_NAME = 'vscode social';
-export const COST_PER_BYTE = new BN("10000000000000000000");
+export const COST_PER_BYTE = new BN("10000000000000000000"); // 1b
+export const DATA_OVERHEAD = 8*5 + 64*4 + 20*4; // 8 bytes for each key (len+dict-size), 64 bytes for accountId, 20bytes for widget-name
 export const TGAS30 = new BN("30"+"0".repeat(12));
 
 export const defaultContext = {

--- a/src/modules/social.ts
+++ b/src/modules/social.ts
@@ -1,6 +1,6 @@
 import { providers, transactions } from "near-api-js";
 import { window } from "vscode";
-import { COST_PER_BYTE, SOCIAL_CONTRACT_ACCOUNT, TGAS30 } from "../config";
+import { COST_PER_BYTE, DATA_OVERHEAD, SOCIAL_CONTRACT_ACCOUNT, TGAS30 } from "../config";
 import BN from "bn.js";
 import * as naj from "near-api-js";
 import { FinalExecutionOutcome } from "near-api-js/lib/providers";
@@ -47,7 +47,7 @@ export const transactionForPublishingCode = async (accountId: AccountId, widgetN
 
   // Amount to pay, based on the size of the data we are storing
   // TODO: Improve this
-  const amount = new BN(JSON.stringify(data).length).mul(COST_PER_BYTE);
+  const amount = new BN(JSON.stringify(data).length + DATA_OVERHEAD).mul(COST_PER_BYTE);
 
   // Create the transaction
   const actions = [transactions.functionCall('set', data, TGAS30, amount)];


### PR DESCRIPTION
VSCODE was attaching the barely minimum for storage, which worked for updating code, but not for creating one (since there is an overhead of extra data).

Could not compute the number, so a fixed magic number is in place for now.